### PR TITLE
[FIX] Contact Field and Report Behavior Alignment

### DIFF
--- a/models/sale_order.py
+++ b/models/sale_order.py
@@ -12,6 +12,11 @@ class SaleOrder(models.Model):
 
     exclude_from_review = fields.Boolean(string="Exclure de l'évaluation du vendeur", tracking=True, copy=False)
 
+    rccm = fields.Char(string='RCCM', help="Registre de Commerce et du Crédit Mobilier - CD/YYY/RCCM/xx-Y-xxxxx (where x = number and Y = capitalised letter)")
+    id_nat = fields.Char(string='Id. Nat.', help="Identification Nationale - xx-Yxxxx-YxxxxxY (where x = number and Y = capitalised letter)")
+    nif = fields.Char(string='NIF', help="Numéro d'Identification Fiscale - YxxxxxxxY (where x = number and Y = capitalised letter)")
+
+
     def write(self, values):
         res = super().write(values)
 

--- a/report/sale_report.xml
+++ b/report/sale_report.xml
@@ -9,7 +9,7 @@
             <field name="report_file">gse_custo.report_saleorder_image</field>
             <field name="print_report_name">(object.state in ('draft', 'sent') and 'Quotation - %s' % (object.name)) or 'Order - %s' % (object.name)</field>
             <field name="binding_model_id" ref="sale.model_sale_order"/>
-            <field name="binding_type">report</field>
+            <field name="binding_type">report</field> 
         </record>
         <record id="action_report_pro_forma_invoice_image" model="ir.actions.report">
             <field name="name">[Image] PRO-FORMA Invoice</field>

--- a/report/sale_report_template.xml
+++ b/report/sale_report_template.xml
@@ -186,6 +186,7 @@
             <t t-set="address">
                 <div t-field="doc.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;], &quot;no_marker&quot;: True}"/>
                 <p t-if="doc.partner_id.vat"><t t-esc="doc.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="doc.partner_id.vat"/></p>
+                <p>NIF: <span t-field="doc.partner_id.vat"/></p>
             </t>
             <t t-if="doc.partner_shipping_id == doc.partner_invoice_id                              and doc.partner_invoice_id != doc.partner_id                              or doc.partner_shipping_id != doc.partner_invoice_id">
                 <t t-set="information_block">

--- a/report/sale_report_template.xml
+++ b/report/sale_report_template.xml
@@ -5,8 +5,15 @@
             <t t-set="doc" t-value="doc.with_context(lang=doc.partner_id.lang)"/>
             <t t-set="forced_vat" t-value="doc.fiscal_position_id.foreign_vat"/> <!-- So that it appears in the footer of the report instead of the company VAT if it's set -->
             <t t-set="address">
-                <div t-field="doc.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;], &quot;no_marker&quot;: True}"/>
-                <p t-if="doc.partner_id.vat"><t t-esc="doc.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="doc.partner_id.vat"/></p>
+                <div t-field="doc.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;, &quot;nif&quot;], &quot;no_marker&quot;: True}"/>
+                <p t-if="doc.partner_id.country_id.code != 'CD'">
+                    <p t-if="doc.partner_id.vat">
+                        <t t-esc="doc.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="doc.partner_id.vat"/></p>
+                </p>
+                <!-- Add nif / rccm / id nat in [image]Quotation/Order -->
+                <p t-if="doc.partner_id.country_id.code == 'CD' and doc.partner_id.nif">NIF: <span t-field="doc.partner_id.nif"/></p>
+                <p t-if="doc.partner_id.country_id.code == 'CD' and doc.partner_id.rccm">RCCM: <span t-field="doc.partner_id.rccm"/></p>
+                <p t-if="doc.partner_id.country_id.code == 'CD' and doc.partner_id.id_nat">Id Nat: <span t-field="doc.partner_id.id_nat"/></p>
             </t>
             <t t-if="doc.partner_shipping_id == doc.partner_invoice_id                              and doc.partner_invoice_id != doc.partner_id                              or doc.partner_shipping_id != doc.partner_invoice_id">
                 <t t-set="information_block">
@@ -53,7 +60,7 @@
                     <div t-if="doc.user_id.name" class="col-auto col-3 mw-100 mb-2">
                         <strong>Salesperson:</strong>
                         <p class="m-0" t-field="doc.user_id"/>
-                    </div>
+                    </div> 
                 </div>
 
                 <!-- Is there a discount on at least one line? -->
@@ -127,7 +134,7 @@
                                         <span t-esc="current_subtotal" t-options="{&quot;widget&quot;: &quot;monetary&quot;, &quot;display_currency&quot;: doc.pricelist_id.currency_id}"/>
                                     </td>
                                 </tr>
-                            </t>
+                            </t> 
                         </t>
                     </tbody>
                 </table>
@@ -387,8 +394,11 @@
         <xpath expr="//t/t/div/table/tbody/t[2]/tr/t/td[2]/span[2]" position="attributes"> 
             <attribute name="style" add="font-size:10px;" separator=" "/>
         </xpath>
+
+        <!--
+        [Image] Quotation / Order
         
-        <!-- <xpath expr="//div[@id='informations']/div[5]" position="replace">
+        <xpath expr="//div[@id='informations']/div[5]" position="replace">
             <div t-if="doc.user_id.name" class="col-auto col-3 mw-100 mb-2">
                 <strong>Salesperson:</strong>
                 <p class="m-0" t-field="doc.user_id"/>
@@ -396,6 +406,7 @@
                 <p class="m-0" t-field="doc.user_id.email"/>
             </div>
         </xpath>
+        
 
         <xpath expr="//t/div/p" position="replace">
             <div style="font-size:10px">

--- a/views/sales_view.xml
+++ b/views/sales_view.xml
@@ -24,6 +24,9 @@
 				</data>
 			</field>
 		</record>
+
+
+
 		<record id="gse_view_order_tree_inherit" model="ir.ui.view">
             <field name="name">sale.order.tree.picking.status</field>
             <field name="model">sale.order</field>


### PR DESCRIPTION
### Rationale 💯 :

This task aims to correct the current system behavior concerning the fields "NIF, RCCM, Id Nat" in the contacts app. Currently, these fields are defined for all contacts, but they should be limited to the contact type = company. Furthermore, it is necessary to ensure that these fields are nor visible nor editable for child contacts. This correction should also be extended to reports so that invoices display these three fields, regardless of the person assigned to the invoice. Before making changes to reports, a verification is required to ensure that the TVA field follows similar behavior.

### Specification ♻️ :

- [ ] NIF, RCCM, Id Nat Fields
     - These fields should only be defined for the parent contact.
     - Child contacts should not have these fields visible.
- [ ] Reports
     - Reports, quotations, sale orders, purchases and invoices, need to be modified to include the NIF, RCCM, and Id Nat fields, irrespective of the person assigned to the invoice.
- [ ] TVA Field Verification
Before proceeding with report modifications, it is essential to verify if the TVA field already follows similar visibility and assignment rules.
- [ ] Matching NIF and TVA for Congo
It is desirable that the NIF field matches the TVA field when the selected country is Congo.