### PR TITLE
[FIX] Contact Field and Report Behavior Alignment(close)

### DIFF
--- a/__manifest__.py
+++ b/__manifest__.py
@@ -29,6 +29,7 @@
         'sale_project',
         'stock',  # qty_available
         'website_sale',  # public_categ_ids
+        'purchase',
     ],
 
     'data': [
@@ -40,6 +41,7 @@
         'report/payment_report_template.xml',
         'report/payment_report.xml',
         'report/mrporder.xml',
+        'report/purchase.xml',
         'views/account_bank_statement.xml',
         'views/recouvrement.xml',
         'views/crm_lead_view.xml',

--- a/models/res_partner.py
+++ b/models/res_partner.py
@@ -14,6 +14,8 @@ class Partner(models.Model):
     id_nat = fields.Char(string='Id. Nat.', help="Identification Nationale - xx-Yxxxx-YxxxxxY (where x = number and Y = capitalised letter)")
     nif = fields.Char(string='NIF', help="Numéro d'Identification Fiscale - YxxxxxxxY (where x = number and Y = capitalised letter)")
 
+    is_child_partner = fields.Boolean(string='Is Child Partner', compute='_compute_is_child_partner', store=True)
+
     @api.constrains('rccm')
     def _check_rccm(self):
         pattern = r'^CD/[A-Z]{3}/RCCM/[0-9]{2}-[A-Z]{1}-[0-9]{5}$'
@@ -39,13 +41,49 @@ class Partner(models.Model):
     def create(self, vals_list):
         for vals in vals_list:
             self._handle_nif_vat_sync(vals)
-        return super().create(vals_list)
+        return super(Partner, self).create(vals_list)
 
     def write(self, values):
         self._handle_nif_vat_sync(values)
-        return super().write(values)
+        return super(Partner, self).write(values)
 
     @api.model
     def _handle_nif_vat_sync(self, vals):
-        if 'nif' in vals:
-            vals['vat'] = vals['nif']
+        for partner in self: 
+            if 'nif' in vals and partner.country_id.code == 'CD': 
+                vals['vat'] = vals['nif'] if vals['nif'] else False
+
+    @api.depends('parent_id', 'child_ids', 'country_id')
+    def _compute_is_child_partner(self):
+        for partner in self:
+            partner.is_child_partner = bool(partner.parent_id or partner.child_ids)
+            # Pass parent values to child if the parent exists
+            if partner.parent_id:
+                partner.nif = partner.parent_id.nif
+                partner.rccm = partner.parent_id.rccm
+                partner.id_nat = partner.parent_id.id_nat 
+
+    @api.onchange('parent_id')
+    def _onchange_parent_id(self):
+        # Trigger the onchange event when the parent_id is changed
+        # This will update the child fields based on the parent's values
+        if self.parent_id:
+            self.nif = self.parent_id.nif
+            self.rccm = self.parent_id.rccm
+            self.id_nat = self.parent_id.id_nat
+            self.vat = self.parent_id.vat
+
+    @api.onchange('country_id')
+    def _onchange_country_id(self): 
+        self.nif = False
+        self.rccm = False
+        self.id_nat = False
+        self.vat = False
+    
+    @api.onchange('is_child_partner')
+    def _onchange_is_child_partner(self): 
+        if not self.is_child_partner:
+            self.nif = False
+            self.rccm = False
+            self.id_nat = False
+            self.vat = False

--- a/models/res_partner.py
+++ b/models/res_partner.py
@@ -14,7 +14,6 @@ class Partner(models.Model):
     id_nat = fields.Char(string='Id. Nat.', help="Identification Nationale - xx-Yxxxx-YxxxxxY (where x = number and Y = capitalised letter)")
     nif = fields.Char(string='NIF', help="Numéro d'Identification Fiscale - YxxxxxxxY (where x = number and Y = capitalised letter)")
 
-    is_child_partner = fields.Boolean(string='Is Child Partner', compute='_compute_is_child_partner', store=True)
 
     @api.constrains('rccm')
     def _check_rccm(self):
@@ -72,6 +71,11 @@ class Partner(models.Model):
             self.rccm = self.parent_id.rccm
             self.id_nat = self.parent_id.id_nat
             self.vat = self.parent_id.vat
+        elif not self.parent_id:
+            self.nif = False
+            self.rccm = False
+            self.id_nat = False
+            self.vat = False
 
     @api.onchange('country_id')
     def _onchange_country_id(self): 
@@ -79,11 +83,3 @@ class Partner(models.Model):
         self.rccm = False
         self.id_nat = False
         self.vat = False
-    
-    @api.onchange('is_child_partner')
-    def _onchange_is_child_partner(self): 
-        if not self.is_child_partner:
-            self.nif = False
-            self.rccm = False
-            self.id_nat = False
-            self.vat = False

--- a/models/sale_order.py
+++ b/models/sale_order.py
@@ -12,6 +12,11 @@ class SaleOrder(models.Model):
 
     exclude_from_review = fields.Boolean(string="Exclure de l'évaluation du vendeur", tracking=True, copy=False)
 
+    rccm = fields.Char(string='RCCM', help="Registre de Commerce et du Crédit Mobilier - CD/YYY/RCCM/xx-Y-xxxxx (where x = number and Y = capitalised letter)")
+    id_nat = fields.Char(string='Id. Nat.', help="Identification Nationale - xx-Yxxxx-YxxxxxY (where x = number and Y = capitalised letter)")
+    nif = fields.Char(string='NIF', help="Numéro d'Identification Fiscale - YxxxxxxxY (where x = number and Y = capitalised letter)")
+
+
     def write(self, values):
         res = super().write(values)
 

--- a/models/sale_order.py
+++ b/models/sale_order.py
@@ -12,11 +12,6 @@ class SaleOrder(models.Model):
 
     exclude_from_review = fields.Boolean(string="Exclure de l'évaluation du vendeur", tracking=True, copy=False)
 
-    rccm = fields.Char(string='RCCM', help="Registre de Commerce et du Crédit Mobilier - CD/YYY/RCCM/xx-Y-xxxxx (where x = number and Y = capitalised letter)")
-    id_nat = fields.Char(string='Id. Nat.', help="Identification Nationale - xx-Yxxxx-YxxxxxY (where x = number and Y = capitalised letter)")
-    nif = fields.Char(string='NIF', help="Numéro d'Identification Fiscale - YxxxxxxxY (where x = number and Y = capitalised letter)")
-
-
     def write(self, values):
         res = super().write(values)
 

--- a/report/account.xml
+++ b/report/account.xml
@@ -5,9 +5,11 @@
             <div class="col-6" name="address_not_same_as_shipping">
                 <t t-set="address">
                     <address class="mb-0" t-field="o.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;], &quot;no_marker&quot;: True}"/>
-                    <div t-if="o.partner_id.vat" id="partner_vat_address_not_same_as_shipping">
-                        <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-esc="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
-                        <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
+                    <div t-if="o.partner_id.country_id.code != 'CD'">
+                        <div t-if="o.partner_id.vat" id="partner_vat_address_not_same_as_shipping">
+                            <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-esc="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
+                            <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
+                        </div>
                     </div>
                     <div t-if="o.partner_id.nif">
                         NIF: <span t-field="o.partner_id.nif"/>
@@ -25,9 +27,11 @@
             <div class="offset-col-6 col-6" name="address_same_as_shipping">
                 <t t-set="address">
                     <address class="mb-0" t-field="o.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;], &quot;no_marker&quot;: True}"/>
-                    <div t-if="o.partner_id.vat" id="partner_vat_address_same_as_shipping">
-                        <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-esc="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
-                        <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
+                    <div t-if="o.partner_id.country_id.code != 'CD'">
+                        <div t-if="o.partner_id.vat" id="partner_vat_address_same_as_shipping">
+                            <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-esc="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
+                            <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
+                        </div>
                     </div>
                     <div t-if="o.partner_id.nif">
                         NIF: <span t-field="o.partner_id.nif"/>
@@ -45,9 +49,11 @@
             <div class="offset-col-6 col-6" name="no_shipping">
                 <t t-set="address">
                     <address class="mb-0" t-field="o.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;], &quot;no_marker&quot;: True}"/>
-                    <div t-if="o.partner_id.vat" id="partner_vat_no_shipping">
-                        <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-esc="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
-                        <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
+                    <div t-if="o.partner_id.country_id.code != 'CD'">
+                        <div t-if="o.partner_id.vat" id="partner_vat_no_shipping">
+                            <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-esc="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
+                            <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
+                        </div>
                     </div>
                     <div t-if="o.partner_id.nif">
                         NIF: <span t-field="o.partner_id.nif"/>

--- a/report/account.xml
+++ b/report/account.xml
@@ -10,15 +10,17 @@
                             <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-esc="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
                             <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
                         </div>
+                    </div> 
+                    <div t-if="o.partner_id.company_type == 'company'">
+                        <span t-if="o.partner_id.nif">NIF: <span t-field="o.partner_id.nif"/></span><br/>
+                        <span t-if="o.partner_id.rccm">RCCM: <span t-field="o.partner_id.rccm"/></span><br/>
+                        <span t-if="o.partner_id.id_nat">Id Nat: <span t-field="o.partner_id.id_nat"/></span><br/>
                     </div>
-                    <div t-if="o.partner_id.nif">
-                        NIF: <span t-field="o.partner_id.nif"/>
-                    </div>
-                    <div t-if="o.partner_id.rccm">
-                        RCCM: <span t-field="o.partner_id.rccm"/>
-                    </div>
-                    <div t-if="o.partner_id.id_nat">
-                        Id.Nat: <span t-field="o.partner_id.id_nat"/>
+                    
+                    <div t-if="o.partner_id.company_type != 'company'">
+                        <span t-if="o.partner_id.parent_id.nif">NIF: <span t-field="o.partner_id.parent_id.nif"/></span><br/>
+                        <span t-if="o.partner_id.parent_id.rccm">RCCM: <span t-field="o.partner_id.parent_id.rccm"/></span><br/>
+                        <span t-if="o.partner_id.parent_id.id_nat">Id Nat: <span t-field="o.partner_id.parent_id.id_nat"/></span><br/>
                     </div>
                 </t>
             </div>
@@ -32,15 +34,17 @@
                             <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-esc="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
                             <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
                         </div>
+                    </div> 
+                    <div t-if="o.partner_id.company_type == 'company'">
+                        <span t-if="o.partner_id.nif">NIF: <span t-field="o.partner_id.nif"/></span><br/>
+                        <span t-if="o.partner_id.rccm">RCCM: <span t-field="o.partner_id.rccm"/></span><br/>
+                        <span t-if="o.partner_id.id_nat">Id Nat: <span t-field="o.partner_id.id_nat"/></span><br/>
                     </div>
-                    <div t-if="o.partner_id.nif">
-                        NIF: <span t-field="o.partner_id.nif"/>
-                    </div>
-                    <div t-if="o.partner_id.rccm">
-                        RCCM: <span t-field="o.partner_id.rccm"/>
-                    </div>
-                    <div t-if="o.partner_id.id_nat">
-                        Id.Nat: <span t-field="o.partner_id.id_nat"/>
+                    
+                    <div t-if="o.partner_id.company_type != 'company'">
+                        <span t-if="o.partner_id.parent_id.nif">NIF: <span t-field="o.partner_id.parent_id.nif"/></span><br/>
+                        <span t-if="o.partner_id.parent_id.rccm">RCCM: <span t-field="o.partner_id.parent_id.rccm"/></span><br/>
+                        <span t-if="o.partner_id.parent_id.id_nat">Id Nat: <span t-field="o.partner_id.parent_id.id_nat"/></span><br/>
                     </div>
                 </t>
             </div>
@@ -54,15 +58,17 @@
                             <t t-if="o.company_id.account_fiscal_country_id.vat_label" t-esc="o.company_id.account_fiscal_country_id.vat_label" id="inv_tax_id_label"/>
                             <t t-else="">Tax ID</t>: <span t-field="o.partner_id.vat"/>
                         </div>
+                    </div> 
+                    <div t-if="o.partner_id.company_type == 'company'">
+                        <span t-if="o.partner_id.nif">NIF: <span t-field="o.partner_id.nif"/></span><br/>
+                        <span t-if="o.partner_id.rccm">RCCM: <span t-field="o.partner_id.rccm"/></span><br/>
+                        <span t-if="o.partner_id.id_nat">Id Nat: <span t-field="o.partner_id.id_nat"/></span><br/>
                     </div>
-                    <div t-if="o.partner_id.nif">
-                        NIF: <span t-field="o.partner_id.nif"/>
-                    </div>
-                    <div t-if="o.partner_id.rccm">
-                        RCCM: <span t-field="o.partner_id.rccm"/>
-                    </div>
-                    <div t-if="o.partner_id.id_nat">
-                        Id.Nat: <span t-field="o.partner_id.id_nat"/>
+                    
+                    <div t-if="o.partner_id.company_type != 'company'">
+                        <span t-if="o.partner_id.parent_id.nif">NIF: <span t-field="o.partner_id.parent_id.nif"/></span><br/>
+                        <span t-if="o.partner_id.parent_id.rccm">RCCM: <span t-field="o.partner_id.parent_id.rccm"/></span><br/>
+                        <span t-if="o.partner_id.parent_id.id_nat">Id Nat: <span t-field="o.partner_id.parent_id.id_nat"/></span><br/>
                     </div>
                 </t>
             </div>

--- a/report/purchase.xml
+++ b/report/purchase.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+	<template id="report_purchaseorder_document_custom" inherit_id="purchase.report_purchaseorder_document">
+        <xpath expr="//*[contains(@t-set, 'address')]" position="replace">
+            <t t-set="address">
+                <div t-field="o.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;, &quot;phone&quot;], &quot;no_marker&quot;: True, &quot;phone_icons&quot;: True}"/>
+                <p t-if="o.partner_id.country_id.code != 'CD'">
+                    <p t-if="o.partner_id.vat">
+                        <t t-esc="o.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="o.partner_id.vat"/></p>
+                </p>
+                <!-- Add nif / rccm / id nat in [image] Purchase/Order -->
+                <span t-if="o.partner_id.nif">NIF: <span t-field="o.partner_id.nif"/></span><br/>
+                <span t-if="o.partner_id.rccm">RCCM: <span t-field="o.partner_id.rccm"/></span><br/>
+                <span t-if="o.partner_id.id_nat">Id Nat: <span t-field="o.partner_id.id_nat"/></span><br/>
+            </t>
+        </xpath>
+	</template>
+
+    <template id="report_purchasequotation_document_custom" inherit_id="purchase.report_purchasequotation_document">
+        <xpath expr="//*[contains(@t-set, 'address')]" position="replace">
+            <t t-set="address">
+                <div t-field="o.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;, &quot;phone&quot;], &quot;no_marker&quot;: True, &quot;phone_icons&quot;: True}"/>
+                <p t-if="o.partner_id.country_id.code != 'CD'">
+                    <p t-if="o.partner_id.vat">
+                        <t t-esc="o.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="o.partner_id.vat"/></p>
+                </p>
+                <!-- Add nif / rccm / id nat in [image]Quotation/Order -->
+                <span t-if="o.partner_id.nif">NIF: <span t-field="o.partner_id.nif"/></span><br/>
+                <span t-if="o.partner_id.rccm">RCCM: <span t-field="o.partner_id.rccm"/></span><br/>
+                <span t-if="o.partner_id.id_nat">Id Nat: <span t-field="o.partner_id.id_nat"/></span><br/>
+            </t>
+        </xpath> 
+	</template>
+</odoo>

--- a/report/purchase.xml
+++ b/report/purchase.xml
@@ -7,11 +7,18 @@
                 <p t-if="o.partner_id.country_id.code != 'CD'">
                     <p t-if="o.partner_id.vat">
                         <t t-esc="o.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="o.partner_id.vat"/></p>
-                </p>
-                <!-- Add nif / rccm / id nat in [image] Purchase/Order -->
-                <span t-if="o.partner_id.nif">NIF: <span t-field="o.partner_id.nif"/></span><br/>
-                <span t-if="o.partner_id.rccm">RCCM: <span t-field="o.partner_id.rccm"/></span><br/>
-                <span t-if="o.partner_id.id_nat">Id Nat: <span t-field="o.partner_id.id_nat"/></span><br/>
+                </p> 
+                <div t-if="o.partner_id.company_type == 'company'">
+                    <span t-if="o.partner_id.nif">NIF: <span t-field="o.partner_id.nif"/></span><br/>
+                    <span t-if="o.partner_id.rccm">RCCM: <span t-field="o.partner_id.rccm"/></span><br/>
+                    <span t-if="o.partner_id.id_nat">Id Nat: <span t-field="o.partner_id.id_nat"/></span><br/>
+                </div>
+                
+                <div t-if="o.partner_id.company_type != 'company'">
+                    <span t-if="o.partner_id.parent_id.nif">NIF: <span t-field="o.partner_id.parent_id.nif"/></span><br/>
+                    <span t-if="o.partner_id.parent_id.rccm">RCCM: <span t-field="o.partner_id.parent_id.rccm"/></span><br/>
+                    <span t-if="o.partner_id.parent_id.id_nat">Id Nat: <span t-field="o.partner_id.parent_id.id_nat"/></span><br/>
+                </div>
             </t>
         </xpath>
 	</template>
@@ -23,11 +30,18 @@
                 <p t-if="o.partner_id.country_id.code != 'CD'">
                     <p t-if="o.partner_id.vat">
                         <t t-esc="o.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="o.partner_id.vat"/></p>
-                </p>
-                <!-- Add nif / rccm / id nat in [image]Quotation/Order -->
-                <span t-if="o.partner_id.nif">NIF: <span t-field="o.partner_id.nif"/></span><br/>
-                <span t-if="o.partner_id.rccm">RCCM: <span t-field="o.partner_id.rccm"/></span><br/>
-                <span t-if="o.partner_id.id_nat">Id Nat: <span t-field="o.partner_id.id_nat"/></span><br/>
+                </p> 
+                <div t-if="o.partner_id.company_type == 'company'">
+                    <span t-if="o.partner_id.nif">NIF: <span t-field="o.partner_id.nif"/></span><br/>
+                    <span t-if="o.partner_id.rccm">RCCM: <span t-field="o.partner_id.rccm"/></span><br/>
+                    <span t-if="o.partner_id.id_nat">Id Nat: <span t-field="o.partner_id.id_nat"/></span><br/>
+                </div>
+                
+                <div t-if="o.partner_id.company_type != 'company'">
+                    <span t-if="o.partner_id.parent_id.nif">NIF: <span t-field="o.partner_id.parent_id.nif"/></span><br/>
+                    <span t-if="o.partner_id.parent_id.rccm">RCCM: <span t-field="o.partner_id.parent_id.rccm"/></span><br/>
+                    <span t-if="o.partner_id.parent_id.id_nat">Id Nat: <span t-field="o.partner_id.parent_id.id_nat"/></span><br/>
+                </div>
             </t>
         </xpath> 
 	</template>

--- a/report/sale_report.xml
+++ b/report/sale_report.xml
@@ -9,7 +9,7 @@
             <field name="report_file">gse_custo.report_saleorder_image</field>
             <field name="print_report_name">(object.state in ('draft', 'sent') and 'Quotation - %s' % (object.name)) or 'Order - %s' % (object.name)</field>
             <field name="binding_model_id" ref="sale.model_sale_order"/>
-            <field name="binding_type">report</field>
+            <field name="binding_type">report</field> 
         </record>
         <record id="action_report_pro_forma_invoice_image" model="ir.actions.report">
             <field name="name">[Image] PRO-FORMA Invoice</field>

--- a/report/sale_report_template.xml
+++ b/report/sale_report_template.xml
@@ -11,9 +11,9 @@
                         <t t-esc="doc.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="doc.partner_id.vat"/></p>
                 </p>
                 <!-- Add nif / rccm / id nat in [image]Quotation/Order -->
-                <p t-if="doc.partner_id.country_id.code == 'CD' and doc.partner_id.nif">NIF: <span t-field="doc.partner_id.nif"/></p>
-                <p t-if="doc.partner_id.country_id.code == 'CD' and doc.partner_id.rccm">RCCM: <span t-field="doc.partner_id.rccm"/></p>
-                <p t-if="doc.partner_id.country_id.code == 'CD' and doc.partner_id.id_nat">Id Nat: <span t-field="doc.partner_id.id_nat"/></p>
+                <span t-if="doc.partner_id.nif">NIF: <span t-field="doc.partner_id.nif"/></span><br/>
+                <span t-if="doc.partner_id.rccm">RCCM: <span t-field="doc.partner_id.rccm"/></span><br/>
+                <span t-if="doc.partner_id.id_nat">Id Nat: <span t-field="doc.partner_id.id_nat"/></span><br/>
             </t>
             <t t-if="doc.partner_shipping_id == doc.partner_invoice_id                              and doc.partner_invoice_id != doc.partner_id                              or doc.partner_shipping_id != doc.partner_invoice_id">
                 <t t-set="information_block">
@@ -186,7 +186,6 @@
             <t t-set="address">
                 <div t-field="doc.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;], &quot;no_marker&quot;: True}"/>
                 <p t-if="doc.partner_id.vat"><t t-esc="doc.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="doc.partner_id.vat"/></p>
-                <p>NIF: <span t-field="doc.partner_id.vat"/></p>
             </t>
             <t t-if="doc.partner_shipping_id == doc.partner_invoice_id                              and doc.partner_invoice_id != doc.partner_id                              or doc.partner_shipping_id != doc.partner_invoice_id">
                 <t t-set="information_block">

--- a/report/sale_report_template.xml
+++ b/report/sale_report_template.xml
@@ -186,6 +186,7 @@
             <t t-set="address">
                 <div t-field="doc.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;], &quot;no_marker&quot;: True}"/>
                 <p t-if="doc.partner_id.vat"><t t-esc="doc.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="doc.partner_id.vat"/></p>
+                <p>NIF: <span t-field="doc.partner_id.vat"/></p>
             </t>
             <t t-if="doc.partner_shipping_id == doc.partner_invoice_id                              and doc.partner_invoice_id != doc.partner_id                              or doc.partner_shipping_id != doc.partner_invoice_id">
                 <t t-set="information_block">

--- a/report/sale_report_template.xml
+++ b/report/sale_report_template.xml
@@ -11,16 +11,22 @@
                         <t t-esc="doc.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="doc.partner_id.vat"/></p>
                 </p>
                 <!-- Add nif / rccm / id nat in [image]Quotation/Order -->
-                <div t-if="doc.partner_id.company_type == 'company'">
+                <div t-if="doc.partner_id.company_type == 'company'"> 
                     <span t-if="doc.partner_id.nif">NIF: <span t-field="doc.partner_id.nif"/></span><br/>
                     <span t-if="doc.partner_id.rccm">RCCM: <span t-field="doc.partner_id.rccm"/></span><br/>
                     <span t-if="doc.partner_id.id_nat">Id Nat: <span t-field="doc.partner_id.id_nat"/></span><br/>
                 </div>
                 
-                <div t-if="doc.partner_id.company_type != 'company'">
+                <div t-if="doc.partner_id.parent_id"> 
                     <span t-if="doc.partner_id.parent_id.nif">NIF: <span t-field="doc.partner_id.parent_id.nif"/></span><br/>
                     <span t-if="doc.partner_id.parent_id.rccm">RCCM: <span t-field="doc.partner_id.parent_id.rccm"/></span><br/>
                     <span t-if="doc.partner_id.parent_id.id_nat">Id Nat: <span t-field="doc.partner_id.parent_id.id_nat"/></span><br/>
+                </div>
+
+                <div t-elif="doc.partner_id.company_type != 'company'">
+                    <span t-if="doc.partner_id.nif">NIF: <span t-field="doc.partner_id.nif"/></span><br/>
+                    <span t-if="doc.partner_id.rccm">RCCM: <span t-field="doc.partner_id.rccm"/></span><br/>
+                    <span t-if="doc.partner_id.id_nat">Id Nat: <span t-field="doc.partner_id.id_nat"/></span><br/>
                 </div>
             </t>
             <t t-if="doc.partner_shipping_id == doc.partner_invoice_id                              and doc.partner_invoice_id != doc.partner_id                              or doc.partner_shipping_id != doc.partner_invoice_id">

--- a/report/sale_report_template.xml
+++ b/report/sale_report_template.xml
@@ -5,15 +5,23 @@
             <t t-set="doc" t-value="doc.with_context(lang=doc.partner_id.lang)"/>
             <t t-set="forced_vat" t-value="doc.fiscal_position_id.foreign_vat"/> <!-- So that it appears in the footer of the report instead of the company VAT if it's set -->
             <t t-set="address">
-                <div t-field="doc.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;, &quot;nif&quot;], &quot;no_marker&quot;: True}"/>
+                <div t-field="doc.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;], &quot;no_marker&quot;: True}"/>
                 <p t-if="doc.partner_id.country_id.code != 'CD'">
                     <p t-if="doc.partner_id.vat">
                         <t t-esc="doc.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="doc.partner_id.vat"/></p>
                 </p>
                 <!-- Add nif / rccm / id nat in [image]Quotation/Order -->
-                <span t-if="doc.partner_id.nif">NIF: <span t-field="doc.partner_id.nif"/></span><br/>
-                <span t-if="doc.partner_id.rccm">RCCM: <span t-field="doc.partner_id.rccm"/></span><br/>
-                <span t-if="doc.partner_id.id_nat">Id Nat: <span t-field="doc.partner_id.id_nat"/></span><br/>
+                <div t-if="doc.partner_id.company_type == 'company'">
+                    <span t-if="doc.partner_id.nif">NIF: <span t-field="doc.partner_id.nif"/></span><br/>
+                    <span t-if="doc.partner_id.rccm">RCCM: <span t-field="doc.partner_id.rccm"/></span><br/>
+                    <span t-if="doc.partner_id.id_nat">Id Nat: <span t-field="doc.partner_id.id_nat"/></span><br/>
+                </div>
+                
+                <div t-if="doc.partner_id.company_type != 'company'">
+                    <span t-if="doc.partner_id.parent_id.nif">NIF: <span t-field="doc.partner_id.parent_id.nif"/></span><br/>
+                    <span t-if="doc.partner_id.parent_id.rccm">RCCM: <span t-field="doc.partner_id.parent_id.rccm"/></span><br/>
+                    <span t-if="doc.partner_id.parent_id.id_nat">Id Nat: <span t-field="doc.partner_id.parent_id.id_nat"/></span><br/>
+                </div>
             </t>
             <t t-if="doc.partner_shipping_id == doc.partner_invoice_id                              and doc.partner_invoice_id != doc.partner_id                              or doc.partner_shipping_id != doc.partner_invoice_id">
                 <t t-set="information_block">

--- a/report/sale_report_template.xml
+++ b/report/sale_report_template.xml
@@ -5,8 +5,15 @@
             <t t-set="doc" t-value="doc.with_context(lang=doc.partner_id.lang)"/>
             <t t-set="forced_vat" t-value="doc.fiscal_position_id.foreign_vat"/> <!-- So that it appears in the footer of the report instead of the company VAT if it's set -->
             <t t-set="address">
-                <div t-field="doc.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;], &quot;no_marker&quot;: True}"/>
-                <p t-if="doc.partner_id.vat"><t t-esc="doc.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="doc.partner_id.vat"/></p>
+                <div t-field="doc.partner_id" t-options="{&quot;widget&quot;: &quot;contact&quot;, &quot;fields&quot;: [&quot;address&quot;, &quot;name&quot;, &quot;nif&quot;], &quot;no_marker&quot;: True}"/>
+                <p t-if="doc.partner_id.country_id.code != 'CD'">
+                    <p t-if="doc.partner_id.vat">
+                        <t t-esc="doc.company_id.account_fiscal_country_id.vat_label or 'Tax ID'"/>: <span t-field="doc.partner_id.vat"/></p>
+                </p>
+                <!-- Add nif / rccm / id nat in [image]Quotation/Order -->
+                <p t-if="doc.partner_id.country_id.code == 'CD' and doc.partner_id.nif">NIF: <span t-field="doc.partner_id.nif"/></p>
+                <p t-if="doc.partner_id.country_id.code == 'CD' and doc.partner_id.rccm">RCCM: <span t-field="doc.partner_id.rccm"/></p>
+                <p t-if="doc.partner_id.country_id.code == 'CD' and doc.partner_id.id_nat">Id Nat: <span t-field="doc.partner_id.id_nat"/></p>
             </t>
             <t t-if="doc.partner_shipping_id == doc.partner_invoice_id                              and doc.partner_invoice_id != doc.partner_id                              or doc.partner_shipping_id != doc.partner_invoice_id">
                 <t t-set="information_block">
@@ -53,7 +60,7 @@
                     <div t-if="doc.user_id.name" class="col-auto col-3 mw-100 mb-2">
                         <strong>Salesperson:</strong>
                         <p class="m-0" t-field="doc.user_id"/>
-                    </div>
+                    </div> 
                 </div>
 
                 <!-- Is there a discount on at least one line? -->
@@ -127,7 +134,7 @@
                                         <span t-esc="current_subtotal" t-options="{&quot;widget&quot;: &quot;monetary&quot;, &quot;display_currency&quot;: doc.pricelist_id.currency_id}"/>
                                     </td>
                                 </tr>
-                            </t>
+                            </t> 
                         </t>
                     </tbody>
                 </table>
@@ -387,8 +394,11 @@
         <xpath expr="//t/t/div/table/tbody/t[2]/tr/t/td[2]/span[2]" position="attributes"> 
             <attribute name="style" add="font-size:10px;" separator=" "/>
         </xpath>
+
+        <!--
+        [Image] Quotation / Order
         
-        <!-- <xpath expr="//div[@id='informations']/div[5]" position="replace">
+        <xpath expr="//div[@id='informations']/div[5]" position="replace">
             <div t-if="doc.user_id.name" class="col-auto col-3 mw-100 mb-2">
                 <strong>Salesperson:</strong>
                 <p class="m-0" t-field="doc.user_id"/>
@@ -396,6 +406,7 @@
                 <p class="m-0" t-field="doc.user_id.email"/>
             </div>
         </xpath>
+        
 
         <xpath expr="//t/div/p" position="replace">
             <div style="font-size:10px">

--- a/views/res_partner.xml
+++ b/views/res_partner.xml
@@ -8,13 +8,14 @@
             <field name="priority" eval="1"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='vat']" position="after"> 
-                    <field name="nif" attrs="{'invisible': ['|', ('company_type', '!=', 'company'), ('country_id', '!=', %(base.cd)d)], }"/>
-                    <field name="rccm" attrs="{'invisible': ['|', ('company_type', '!=', 'company'),('country_id', '!=', %(base.cd)d)], }"/>
-                    <field name="id_nat" attrs="{'invisible': ['|', ('company_type', '!=', 'company'),('country_id', '!=', %(base.cd)d)], }"/> 
+                    <field name="nif" attrs="{'invisible': ['|', ('country_id', '!=', %(base.cd)d), '&amp;',('is_child_partner', '=', True),('company_type', '!=', 'company') ,], }"/>
+                    <field name="rccm" attrs="{'invisible': ['|', ('country_id', '!=', %(base.cd)d),'&amp;',('is_child_partner', '=', True),('company_type', '!=', 'company'),], }"/>
+                    <field name="id_nat" attrs="{'invisible': ['|', ('country_id', '!=', %(base.cd)d),'&amp;',('is_child_partner', '=', True),('company_type', '!=', 'company') ,], }"/> 
+                    <field name="is_child_partner" attrs="{'invisible': [('id', '!=', False)]}" />
                 </xpath>
                 <xpath expr="//field[@name='vat']" position="attributes">
                     <attribute name="attrs">{'readonly': [('country_id', '=', %(base.cd)d)]}</attribute>
-                    <attribute name="attrs">{'invisible': [('country_id', '=', %(base.cd)d)]}</attribute>
+                    <attribute name="attrs">{'invisible': ['|', ('country_id', '=', %(base.cd)d),'&amp;',('is_child_partner', '=', True), ('company_type', '!=', 'company')]}</attribute> 
                 </xpath>
             </field>
         </record>

--- a/views/res_partner.xml
+++ b/views/res_partner.xml
@@ -7,10 +7,10 @@
             <field name="inherit_id" ref="base.view_partner_form" />
             <field name="priority" eval="1"/>
             <field name="arch" type="xml">
-                <xpath expr="//field[@name='vat']" position="after">
-                    <field name="nif" attrs="{'invisible': [('country_id', '!=', %(base.cd)d)], }"/>
-                    <field name="rccm" attrs="{'invisible': [('country_id', '!=', %(base.cd)d)], }"/>
-                    <field name="id_nat" attrs="{'invisible': [('country_id', '!=', %(base.cd)d)], }"/>
+                <xpath expr="//field[@name='vat']" position="after"> 
+                    <field name="nif" attrs="{'invisible': ['|', ('company_type', '!=', 'company'), ('country_id', '!=', %(base.cd)d)], }"/>
+                    <field name="rccm" attrs="{'invisible': ['|', ('company_type', '!=', 'company'),('country_id', '!=', %(base.cd)d)], }"/>
+                    <field name="id_nat" attrs="{'invisible': ['|', ('company_type', '!=', 'company'),('country_id', '!=', %(base.cd)d)], }"/> 
                 </xpath>
                 <xpath expr="//field[@name='vat']" position="attributes">
                     <attribute name="attrs">{'readonly': [('country_id', '=', %(base.cd)d)]}</attribute>

--- a/views/res_partner.xml
+++ b/views/res_partner.xml
@@ -8,14 +8,13 @@
             <field name="priority" eval="1"/>
             <field name="arch" type="xml">
                 <xpath expr="//field[@name='vat']" position="after"> 
-                    <field name="nif" attrs="{'invisible': ['|', ('country_id', '!=', %(base.cd)d), '&amp;',('is_child_partner', '=', True),('company_type', '!=', 'company') ,], }"/>
-                    <field name="rccm" attrs="{'invisible': ['|', ('country_id', '!=', %(base.cd)d),'&amp;',('is_child_partner', '=', True),('company_type', '!=', 'company'),], }"/>
-                    <field name="id_nat" attrs="{'invisible': ['|', ('country_id', '!=', %(base.cd)d),'&amp;',('is_child_partner', '=', True),('company_type', '!=', 'company') ,], }"/> 
-                    <field name="is_child_partner" attrs="{'invisible': [('id', '!=', False)]}" />
+                    <field name="nif" attrs="{'invisible': ['|', ('country_id', '!=', %(base.cd)d), '&amp;',('parent_id', '!=', False),('company_type', '!=', 'company') ,], }"/>
+                    <field name="rccm" attrs="{'invisible': ['|', ('country_id', '!=', %(base.cd)d),'&amp;',('parent_id', '!=', False),('company_type', '!=', 'company'),], }"/>
+                    <field name="id_nat" attrs="{'invisible': ['|', ('country_id', '!=', %(base.cd)d),'&amp;',('parent_id', '!=', False),('company_type', '!=', 'company') ,], }"/>
                 </xpath>
                 <xpath expr="//field[@name='vat']" position="attributes">
                     <attribute name="attrs">{'readonly': [('country_id', '=', %(base.cd)d)]}</attribute>
-                    <attribute name="attrs">{'invisible': ['|', ('country_id', '=', %(base.cd)d),'&amp;',('is_child_partner', '=', True), ('company_type', '!=', 'company')]}</attribute> 
+                    <attribute name="attrs">{'invisible': ['|', ('country_id', '=', %(base.cd)d),'&amp;',('parent_id', '!=', False), ('company_type', '!=', 'company')]}</attribute> 
                 </xpath>
             </field>
         </record>

--- a/views/sales_view.xml
+++ b/views/sales_view.xml
@@ -24,6 +24,9 @@
 				</data>
 			</field>
 		</record>
+
+
+
 		<record id="gse_view_order_tree_inherit" model="ir.ui.view">
             <field name="name">sale.order.tree.picking.status</field>
             <field name="model">sale.order</field>


### PR DESCRIPTION
### Rationale 💯 :

This task aims to correct the current system behavior concerning the fields "NIF, RCCM, Id Nat" in the contacts app. Currently, these fields are defined for all contacts, but they should be limited to the contact type = company. Furthermore, it is necessary to ensure that these fields are nor visible nor editable for child contacts. This correction should also be extended to reports so that invoices display these three fields, regardless of the person assigned to the invoice. Before making changes to reports, a verification is required to ensure that the TVA field follows similar behavior.

### Specification ♻️ :

- [ ] NIF, RCCM, Id Nat Fields
     - These fields should only be defined for the parent contact.
     - Child contacts should not have these fields visible.
- [ ] Reports
     - Reports, quotations, sale orders, purchases and invoices, need to be modified to include the NIF, RCCM, and Id Nat fields, irrespective of the person assigned to the invoice.
- [ ] TVA Field Verification
Before proceeding with report modifications, it is essential to verify if the TVA field already follows similar visibility and assignment rules.
- [ ] Matching NIF and TVA for Congo
It is desirable that the NIF field matches the TVA field when the selected country is Congo.