### PR TITLE
[IMP] Purchase: sales history and quality check

### DIFF
--- a/models/account_move.py
+++ b/models/account_move.py
@@ -15,15 +15,8 @@ class AccountMove(models.Model):
     preuve_paiement = fields.Boolean()
     dossier_complet = fields.Boolean()
     travaux_termines = fields.Boolean()
-    salesperson_eval = fields.Boolean(
-        string="Exclure de l'évaluation du vendeur",
-        tracking=True,
-    )
-    salesperson_eval_reason = fields.Char(
-        string='Raison', tracking=True,
-    )
+    salesperson_eval_reason = fields.Char(string='Raison', tracking=True)
     derniere_date_paiement = fields.Date(compute='_compute_derniere_date_paiement')
-
     exclude_from_review = fields.Boolean(string="Exclure de l'évaluation du vendeur", tracking=True, copy=False)
 
     def _compute_derniere_date_paiement(self):

--- a/models/purchase_order.py
+++ b/models/purchase_order.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from odoo import fields, models
+from odoo import fields, models,api
 
 
 class PurchaseOrder(models.Model):
@@ -19,3 +19,38 @@ class PurchaseOrderLine(models.Model):
     _inherit = "purchase.order.line"
 
     quantity_available_gse = fields.Float(related="product_id.qty_available")
+    sales_per_year = fields.Float(
+        related="product_id.sales_count", string="Sales (Last 365 days)"
+    )
+    color = fields.Integer(default=2, compute="_compute_color", readonly=True)
+    product_need_count = fields.Float(
+        string="Qty Needed",
+        digits="Product Unit of Measure",
+        compute="_compute_product_need_count",
+    )
+    sale_order_lines = fields.One2many(
+        "sale.order.line", "order_id", string="Sale Order Lines"
+    )
+
+    @api.depends("sale_order_lines")
+    def _compute_product_need_count(self):
+        for product in self:
+            domain = [
+                ("order_id.state", "=", "draft"),
+                ("name", "=", product.name),
+            ]
+            total_quantity = sum(
+                product.sale_order_lines.search(domain).mapped("product_uom_qty")
+            )
+            product.product_need_count = total_quantity
+
+    @api.depends("quantity_available_gse", "product_need_count", "sales_per_year")
+    def _compute_color(self):
+        for product in self:
+            if product.quantity_available_gse <= product.product_need_count:
+                product.color = 10  # Green color
+            elif (
+                product.quantity_available_gse > product.product_need_count
+                or product.sales_per_year <= product.quantity_available_gse
+            ):
+                product.color = 9  # Red color

--- a/views/purchase_view.xml
+++ b/views/purchase_view.xml
@@ -12,6 +12,9 @@
 					</xpath>
 					<xpath expr="//form[1]/sheet[1]/notebook[1]/page[@name='products']/field[@name='order_line']/tree[1]/field[@name='name']" position="after">
 						<field optional="show" name="quantity_available_gse" string="Qty on Hand"/>
+						<field optional="show" name="sales_per_year" string="Total Sales"/>
+						<field optional="show" name="color" widget="color_picker" string="QC"/>
+						<field optional="show" name="product_need_count" string="Qty Needed"/>
 					</xpath>
 					<xpath expr="//button[@name='button_cancel']" position="attributes">
 						<attribute name="groups">gse_custo.group_purchase_super_admin </attribute>

--- a/views/recouvrement.xml
+++ b/views/recouvrement.xml
@@ -28,11 +28,9 @@
 									<field name="dossier_complet" string="Dossier complet"/>
 									<field name="travaux_termines" string="Travaux terminés"/>
 									<!-- need this field in invisible for salesperson_eval_reason which relies on it -->
-									<field name="salesperson_eval" invisible="1"/>
-									<field name="salesperson_eval" groups="gse_custo.group_recouvrement,account.group_account_user" help="Ne pas considérer cette vente dans l'évaluation du vendeur pour défaut de documentation"/>
 									<field name="exclude_from_review" invisible="1"/>
 									<field name="exclude_from_review" groups="gse_custo.group_recouvrement,account.group_account_user" string="Excl. éval vendeur"/>
-									<field name="salesperson_eval_reason" attrs="{'invisible': [['salesperson_eval','=',False]]}"/>
+									<field name="salesperson_eval_reason" attrs="{'invisible': [['exclude_from_review','=',False]]}"/>
 								</group>
 							</group>
 						</page>


### PR DESCRIPTION
### Rationale

We speed up the purchase's validation process by the adding of some information, the quantity on hand and the price of the previous purchase.
One information may help, the number of sales in the 365 previous days.

### Specification
Add a column, next to the quantity on hand, with the number of sales in the last 365 days.
Add another column with a 'quality checker', this info should compare the quantity on hand, need , the quantity sale in the last 365 days and the lead time for the purchase.
- Make something visual, 3 colors:
         - Green: Ok
         - Orange: Check