### PR TITLE
[FIX] sale: Avoid recursion in get_recursively_not_directly_related

### DIFF
--- a/models/sale_order.py
+++ b/models/sale_order.py
@@ -22,25 +22,38 @@ class SaleOrder(models.Model):
 
     def write(self, values):
         res = super().write(values)
-
         if 'exclude_from_review' in values and not self._context.get('ignore_exclude_from_review'):
             orders, invoices = self.get_recursively_not_directly_related()
             orders.with_context(ignore_exclude_from_review=True).exclude_from_review = values['exclude_from_review']
             invoices.with_context(ignore_exclude_from_review=True).exclude_from_review = values['exclude_from_review']
-
         return res
 
-    def get_recursively_not_directly_related(self, all_orders=None, all_invoices=None):
-        # Care that it could auto discover one that has already been
-        # discovered and enter infinite loop
+    def get_recursively_not_directly_related(self, all_orders=None, all_invoices=None, visited_orders=None):
+        # Initialisation des ensembles pour stocker les commandes et factures traitées
         all_invoices = all_invoices or self.env['account.move']
         all_orders = all_orders or self.env['sale.order']
+        # La variable visited_orders est nécessaire pour éviter la récursion infinie et optimiser le traitement.
+        # Utiliser un set pour visited_orders assure que les opérations de vérification sont rapides (O(1)).
+        visited_orders = visited_orders or set()
+        # Ajoutez les commandes actuelles à l'ensemble des commandes traitées
         all_orders |= self
+    
+        # Parcourez chaque commande
         for order in self:
+            # Si la commande a déjà été visitée, sautez-la pour éviter la récursion infinie
+            if order.id in visited_orders:
+                continue
+            # Marquez la commande actuelle comme visitée
+            visited_orders.add(order.id)
+            # Récupérez les factures liées à la commande
             related_invoices = order.order_line.invoice_lines.move_id
+            # Récupérez les commandes liées aux factures découvertes
             related_orders = related_invoices.line_ids.sale_line_ids.order_id
+            # Filtrez les nouvelles commandes non encore explorées
             new_discovered_orders = related_orders.filtered(lambda o: o not in all_orders)
-            oo, ii = new_discovered_orders.get_recursively_not_directly_related()
+            # Récursion avec les nouvelles commandes découvertes
+            oo, ii = new_discovered_orders.get_recursively_not_directly_related(all_orders, all_invoices, visited_orders)
+            # Ajoutez les nouvelles factures et commandes aux ensembles
             all_invoices |= related_invoices | ii
             all_orders |= related_orders | oo
         return all_orders, all_invoices


### PR DESCRIPTION

This fix prevents the infinite recursion issue in the sale order discovery function
`get_recursively_not_directly_related`. A set `visited_orders` is introduced to
track orders that have already been processed, thus avoiding infinite loops.

Steps:
- Add `visited_orders` to track processed orders.
- Ensure that each order is only processed once.
- Return the accumulated orders and invoices without revisiting any records.
